### PR TITLE
fix(active-speaker-ui): adding order hint for react, for the multiple screenshares usecase

### DIFF
--- a/react-examples/examples/active-speaker-ui/src/components/ScreenShareView.tsx
+++ b/react-examples/examples/active-speaker-ui/src/components/ScreenShareView.tsx
@@ -28,6 +28,7 @@ export default function ScreenShareView({
     <RtkScreenshareView
       meeting={meeting}
       participant={participant}
+      key={participant.id}
       className="flex-1 relative"
       // hidden default full screen button
       hideFullScreenButton


### PR DESCRIPTION
React is trying to reuse a previously rendered screenshare view out of sequence due to lack of key prop. This causes screenshare to not be visible if we are going from 2 screenshares to 1. Adding the key prop to help react differentiate the components. We will be adding foolproofing in ui-kit components too but for now, altering the example to ensure it works in the mean time.

### Screenshots
Example when this issue occurs
<img width="1351" height="759" alt="image" src="https://github.com/user-attachments/assets/dde93903-714e-4d8c-80ce-6cab0b01066b" />
