### PR TITLE
feat(plugins): add DocShare and Streamer plugins to plugins example

### DIFF
--- a/react-examples/examples/plugins/src/App.tsx
+++ b/react-examples/examples/plugins/src/App.tsx
@@ -6,7 +6,10 @@ const WHITEBOARD_URL = 'https://whiteboard-collabkit.cf-realtime.workers.dev';
 const WHITEBOARD_ICON =
   'https://whiteboard-collabkit.cf-realtime.workers.dev/logo.png';
 
-function createWhiteboardIframe(): HTMLIFrameElement {
+const DOCSHARE_URL = 'https://docshare-collabkit.cf-realtime.workers.dev';
+const STREAMER_URL = 'https://streamer-collabkit.cf-realtime.workers.dev';
+
+function createPluginIframe(): HTMLIFrameElement {
   const iframe = document.createElement('iframe');
   iframe.style.width = '100%';
   iframe.style.height = '100%';
@@ -17,9 +20,19 @@ function createWhiteboardIframe(): HTMLIFrameElement {
 
 function App() {
   const [meeting, initMeeting] = useRealtimeKitClient();
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  if (!iframeRef.current) {
-    iframeRef.current = createWhiteboardIframe();
+  const whiteboardIframeRef = useRef<HTMLIFrameElement | null>(null);
+  if (!whiteboardIframeRef.current) {
+    whiteboardIframeRef.current = createPluginIframe();
+  }
+
+  const docshareIframeRef = useRef<HTMLIFrameElement | null>(null);
+  if (!docshareIframeRef.current) {
+    docshareIframeRef.current = createPluginIframe();
+  }
+
+  const streamerIframeRef = useRef<HTMLIFrameElement | null>(null);
+  if (!streamerIframeRef.current) {
+    streamerIframeRef.current = createPluginIframe();
   }
 
   useEffect(() => {
@@ -51,7 +64,27 @@ function App() {
               canActivate: true,
               canDeactivate: true,
             },
-            component: iframeRef.current,
+            component: whiteboardIframeRef.current,
+          },
+          {
+            id: 'docshare',
+            name: 'DocShare',
+            icon: `${DOCSHARE_URL}/document.png`,
+            permissions: {
+              canActivate: true,
+              canDeactivate: true,
+            },
+            component: docshareIframeRef.current,
+          },
+          {
+            id: 'streamer',
+            name: 'Streamer',
+            icon: `${STREAMER_URL}/logo.png`,
+            permissions: {
+              canActivate: true,
+              canDeactivate: true,
+            },
+            component: streamerIframeRef.current,
           },
         ],
       },
@@ -69,7 +102,23 @@ function App() {
         params.set('profilePicture', m.self.picture);
       }
 
-      iframeRef.current!.src = `${WHITEBOARD_URL}?${params.toString()}`;
+      whiteboardIframeRef.current!.src = `${WHITEBOARD_URL}?${params.toString()}`;
+
+      const docshareParams = new URLSearchParams({
+        roomId: m.meta.meetingId,
+        roomName: m.meta.meetingTitle || 'DocShare',
+        userId: m.self.id,
+        userName: m.self.name,
+      });
+      docshareIframeRef.current!.src = `${DOCSHARE_URL}?${docshareParams.toString()}`;
+
+      const streamerParams = new URLSearchParams({
+        roomId: m.meta.meetingId,
+        roomName: m.meta.meetingTitle || 'Streamer',
+        userId: m.self.id,
+        userName: m.self.name,
+      });
+      streamerIframeRef.current!.src = `${STREAMER_URL}?${streamerParams.toString()}`;
     }).catch(console.error);
   }, []);
 


### PR DESCRIPTION
This PR adds DocShare and Streamer plugin registrations to the plugins example app.

## TODO before marking ready

- [x] Replace `DOCSHARE_URL` with production URL
- [x] Replace `STREAMER_URL` with production URL
- [x] Test with production deployments


closes: RTK-8229